### PR TITLE
feat: use variant prop to alter message layout and content

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   message_text:
     description: 'Optional message text'
     required: false
+  variant:
+    description: sm | lg
+    required: false,
+    default: lg
 outputs:
   message_id:
     description: 'The unique timestamp identifier of the Slack message sent'

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const { buildSlackAttachments, formatChannelName } = require('./src/utils');
     const color = core.getInput('color');
     const messageId = core.getInput('message_id');
     const messageText = core.getInput('message_text');
+    const variant = core.getInput('variant') ?? 'lg';
     const token = process.env.SLACK_BOT_TOKEN;
     const slack = new WebClient(token);
 
@@ -27,17 +28,12 @@ const { buildSlackAttachments, formatChannelName } = require('./src/utils');
     }
 
     const apiMethod = Boolean(messageId) ? 'update' : 'postMessage';
-
     const args = {
       channel: channelId,
-      text: messageText || undefined,
-      attachments,
+      text: messageText,
+      attachments: variant === 'lg' ? attachments : undefined,
+      ts: messageId,
     };
-
-    if (messageId) {
-      args.ts = messageId;
-    }
-
     const response = await slack.chat[apiMethod](args);
 
     core.setOutput('message_id', response.ts);


### PR DESCRIPTION
## Purpose
Adding the concept of `variant` draws from our expected rendering customizations. In this case we extend the notion that a notification can have a large or small presentation. Drawing on the frontend convention — of which a notification is subject to 😉 — we use the `sm` and `lg` aliases.

## Important Changes

When using the small variant — `sm` — you will see only the text input. Thus taking up a slimmer and more reasonable amount of space in a channel actively used by humans.

Related to [frontend-core/pull/2914](https://github.com/updater/frontend-core/pull/2914)